### PR TITLE
Heroku deploy fix: start web app with gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN apt-get update &&\
     adduser myuser
 WORKDIR /home/myuser
 COPY --chown=myuser:myuser . .
-#CMD gunicorn -w 4 --bind 0.0.0.0:$PORT "app:create_app()"
+CMD gunicorn -w 4 --bind 0.0.0.0:$PORT "app:create_app()"


### PR DESCRIPTION
Add the gunicorn command in the Dockerfile. This should deploy the web app to heroku.